### PR TITLE
[Atlas]Added torchrun support

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -26,12 +26,14 @@ def _get_eval_data_iterator(opt, data_path, task):
     data_iterator = task.data_iterator(data_path, opt.global_rank, opt.world_size, opt=opt, is_eval=True)
     data_iterator = filter(None, map(task.process, data_iterator))
     data_iterator = list(task.batch_iterator(data_iterator, opt.per_gpu_batch_size))
+    print("we are here", dist.get_world_size(), dist.get_rank(), torch.cuda.device_count())
     if dist.is_initialized():
-        len_data = torch.tensor(len(data_iterator)).cuda()
+        len_data = torch.tensor(len(data_iterator), device=torch.device("cuda"))
         dist.all_reduce(len_data, torch.distributed.ReduceOp.MAX)
+        dist.barrier()
         if len(data_iterator) < len_data.item():
             data_iterator.extend([{} for _ in range(len_data.item() - len(data_iterator))])
-    dist.barrier()
+
     return data_iterator
 
 
@@ -63,7 +65,6 @@ def run_retrieval_only(model, index, opt, data_path, step=None):
         # If example is a padding example then skip step
         if (len(query) == 0) or (len(query[0]) == 0):
             continue
-
         for k in range(len(retrieved_passages)):
             if opt.write_results:
                 gold = [answers[k]] if not "answers" in batch else batch["answers"][k]
@@ -92,7 +93,7 @@ def evaluate(model, index, opt, data_path, step=None):
 
     task = get_task(opt, reader_tokenizer)
     data_iterator = _get_eval_data_iterator(opt, data_path, task)
-
+    print(" completed data iterator")
     for i, batch in enumerate(data_iterator):
         query = batch.get("query", [""])
         answers = batch.get("target", [""])
@@ -118,16 +119,17 @@ def evaluate(model, index, opt, data_path, step=None):
         # If example is a padding example then skip step
         if (len(query) == 0) or (len(query[0]) == 0):
             continue
-
+        print(" completed for in data iterator")
         reader_tokens, _ = unwrapped_model.tokenize_passages(query, retrieved_passages)
 
         if "eval_loss" in task.metrics:
             eval_loss, logits = unwrapped_model.compute_reader_loss_and_logits(reader_tokens, decoder_input_ids, labels)
             metrics["eval_loss"].append(eval_loss)
-
+        print(" try to generate")
         generation = unwrapped_model.generate(
             reader_tokens, query, choices=batch["choices"] if "choices" in batch else None
         )
+        print(" finished generating")
 
         for k, g in enumerate(generation):
             if opt.decoder_prompt_format is not None:
@@ -153,10 +155,13 @@ def evaluate(model, index, opt, data_path, step=None):
                     ex["id"] = batch["id"][k]
                 dataset_wpred.append(ex)
 
+    print(" going thru generation stuff")
     metrics, dataset_wpred = task.evaluation_postprocessing(metrics, dataset_wpred)
+    print("finished metrics")
     metrics = util.avg_dist_dict(task.metrics, metrics)
+    print("weird metrics stuff")
     metrics = {key: value if key == "eval_loss" else 100 * value for key, value in metrics.items()}
-
+    print("finished metrics")
     if opt.write_results:
         dataset_name, _ = os.path.splitext(os.path.basename(data_path))
         dataset_name = f"{dataset_name}-step-{step}"

--- a/finetune_qa.py
+++ b/finetune_qa.py
@@ -11,6 +11,7 @@ import numpy as np
 import torch
 import torch.cuda
 import sys
+from src.torchrun_utils import init_distributed_mode_torchrun
 from src import dist_utils, slurm, util
 from src.index_io import load_or_initialize_index
 from src.model_io import create_checkpoint_directories, load_or_initialize_atlas_model
@@ -91,7 +92,8 @@ if __name__ == "__main__":
     opt = set_parser_options(options.parser, sys.argv[1:])
 
     torch.manual_seed(opt.seed)
-    slurm.init_distributed_mode(opt)
+    #slurm.init_distributed_mode(opt)
+    init_distributed_mode_torchrun(opt)
     slurm.init_signal_handler()
 
     checkpoint_path, saved_index_path = create_checkpoint_directories(opt)

--- a/finetune_qa.py
+++ b/finetune_qa.py
@@ -17,10 +17,11 @@ from src.index_io import load_or_initialize_index
 from src.model_io import create_checkpoint_directories, load_or_initialize_atlas_model
 from src.options import get_options
 from train import train
+import torch.distributed as dist
 
 os.environ["TOKENIZERS_PARALLELISM"] = "true"
 NCONTEXT: str = "40"
-PBSZ: str = "2"
+PBSZ: str = "3"
 PRECISION: str = "bf16"
 GOLD_SCORE_MODE: str = "ppmean"
 GPU_MAX_LENGTH: str = "384"
@@ -92,7 +93,7 @@ if __name__ == "__main__":
     opt = set_parser_options(options.parser, sys.argv[1:])
 
     torch.manual_seed(opt.seed)
-    #slurm.init_distributed_mode(opt)
+    # slurm.init_distributed_mode(opt)
     init_distributed_mode_torchrun(opt)
     slurm.init_signal_handler()
 
@@ -126,7 +127,7 @@ if __name__ == "__main__":
                 find_unused_parameters=True,
             )
             model._set_static_graph()
-
+        torch.cuda.set_device(dist.get_rank())
     logger.info("Start finetuning")
     dist_utils.barrier()
     train(

--- a/finetune_qa.py
+++ b/finetune_qa.py
@@ -8,6 +8,7 @@ import os
 from typing import List
 import argparse
 import numpy as np
+import random
 import torch
 import torch.cuda
 import sys
@@ -29,16 +30,40 @@ GEN_MAX_LENGTH: str = "32"
 EPSILON: str = "0.01"
 SMALL_EPSILON: str = "4e-5"
 DROPOUT: str = "0.1"
-NO_WARMUP_STEPS: str = "0"
+WARMUP_STEPS: str = "5"
+EVAL_FREQ: str = "10"
+LOG_FREQ: str = "5"
 NO_REFRESH: str = "-1"
+CHECK_FREQS: List[str] = ["--warmup_steps", "--save_freq", "--eval_freq"]
+PORT: str = str(random.randrange(15000, 16000))
+
+
+def get_argument_value(all_args: List[str], argument_name: str) -> int:
+
+    argument_idx = all_args.index(argument_name)
+    return int(all_args[argument_idx + 1])
+
+
+def check_valid_input_params(all_args: List[str], total_steps: int) -> None:
+
+    for freq in CHECK_FREQS:
+        try:
+            arg_val = get_argument_value(all_args, freq)
+        except ValueError:
+            print(f"List does not contain value {freq}")
+
+        assert arg_val < total_steps, f"The {freq} cannot be higher than the total steps {total_steps}. "
 
 
 def set_parser_options(parser: argparse.Namespace, passed_args: List[str]) -> argparse.ArgumentParser:
     """
-    Sets some default options for finetuning an Atlas model for a q&a task.
+    Sets the default options for finetuning an Atlas model for a q&a task.
     """
 
+    total_steps = get_argument_value(passed_args, "--total_steps")
+
     all_args = [
+        "--write_results",
         "--train_retriever",
         "--query_side_retriever_training",
         "--use_gradient_checkpoint_reader",
@@ -82,9 +107,18 @@ def set_parser_options(parser: argparse.Namespace, passed_args: List[str]) -> ar
         "--refresh_index",
         NO_REFRESH,
         "--warmup_steps",
-        NO_WARMUP_STEPS,
+        WARMUP_STEPS,
+        "--save_freq",
+        str(total_steps - 1),
+        "--eval_freq",
+        EVAL_FREQ,
+        "--log_freq",
+        LOG_FREQ,
+        "--main_port",
+        PORT,
     ] + passed_args
 
+    check_valid_input_params(all_args, total_steps)
     return parser.parse_args(all_args)
 
 

--- a/src/index.py
+++ b/src/index.py
@@ -129,7 +129,7 @@ class DistributedIndex(object):
         allsizes = np.cumsum([0] + allsizes.cpu().tolist())
         # compute scores for the part of the index located on each process
         scores, indices = self._compute_scores_and_indices(allqueries, topk)
-        indices = indices.cpu().tolist()
+        indices = indices.tolist()
         docs = [[self.doc_map[x] for x in sample_indices] for sample_indices in indices]
         if torch.distributed.is_initialized():
             docs = [docs[allsizes[k] : allsizes[k + 1]] for k in range(len(allsizes) - 1)]

--- a/src/index.py
+++ b/src/index.py
@@ -116,17 +116,7 @@ class DistributedIndex(object):
         """
         scores = torch.matmul(allqueries.half(), self.embeddings)
         scores, indices = torch.topk(scores, topk, dim=1)
-        # dimension, num_points = self.embeddings.shape
-        # gpu_resources = faiss.StandardGpuResources()
-        # cfg = faiss.GpuIndexFlatConfig()
-        # cfg.useFloat16 = True
-        # gpu_index = faiss.GpuIndexFlatIP(gpu_resources, dimension, cfg)
-        # if gpu_index.ntotal == 0:
-        #    embeddings = self.embeddings.T
-        #    gpu_index.add(embeddings.type(torch.float32).contiguous())
-        # import math
-        # gpu_index.nprobe = math.floor(math.sqrt(num_points))
-        # scores, indices = gpu_index.search(allqueries.type(torch.float32), topk)
+
         return scores, indices
 
     @torch.no_grad()

--- a/src/index_io.py
+++ b/src/index_io.py
@@ -75,7 +75,7 @@ def load_or_initialize_index(opt):
     elif opt.index_mode == "faiss":
         index = DistributedFAISSIndex(opt.faiss_index_type, opt.faiss_code_size)
     else:
-        raise ValueError(f"unsupported index mode {opt.faiss_index_mode}")
+        raise ValueError(f"unsupported index mode {opt.index_mode}")
 
     if opt.load_index_path is not None:
         logger.info(f"Loading index from: {opt.load_index_path} with index mode: {opt.index_mode}")

--- a/src/torchrun_utils.py
+++ b/src/torchrun_utils.py
@@ -6,12 +6,8 @@
 
 import datetime
 import os
-import signal
-import socket
 import subprocess
-import sys
 from logging import getLogger
-
 import torch
 
 logger = getLogger()
@@ -26,15 +22,9 @@ def init_distributed_mode_torchrun(params):
         - local_rank
         - global_rank
         - world_size
-    """
-    # for NCCL verbose mode
+    For NCCL verbose mode, use:
     os.environ["NCCL_DEBUG"] = "INFO"
-    # os.environ["NCCL_DEBUG_SUBSYS"]="ALL"
-    # os.environ["NCCL_P2P_DISABLE"]="1"
-    # os.environ["CUDA_LAUNCH_BLOCKING"]="1"
-    # os.environ["NCCL_IB_DISABLE"]="1"
-    # os.environ["NCCL_LL_THRESHOLD"]="0" #try this
-    # os.environ["MKL_NUM_THREADS"]="1"
+    """
     params.local_rank = int(os.environ["LOCAL_RANK"])
     params.node_id = 0
     params.n_nodes = 1
@@ -48,8 +38,7 @@ def init_distributed_mode_torchrun(params):
 
     # summary
     PREFIX = "%i - " % params.global_rank
-    # define master address
-    # tbc
+
     # set GPU device
     if params.is_distributed:
         torch.cuda.set_device(params.local_rank)
@@ -83,5 +72,7 @@ def init_distributed_mode_torchrun(params):
         global GLOO_GROUP
 
         GLOO_GROUP = torch.distributed.new_group(
-            list(range(params.world_size)), backend="gloo", timeout=datetime.timedelta(0, 600)
+            list(range(params.world_size)),
+            backend="gloo",
+            timeout=datetime.timedelta(0, 600),
         )

--- a/src/torchrun_utils.py
+++ b/src/torchrun_utils.py
@@ -1,0 +1,81 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import datetime
+import os
+import signal
+import socket
+import subprocess
+import sys
+from logging import getLogger
+
+import torch
+
+logger = getLogger()
+
+def init_distributed_mode_torchrun(params):
+    """
+    Handle single and multi-GPU for singe-node jobs with torchrun.
+    Initialize the following variables:
+        - n_nodes
+        - node_id
+        - local_rank
+        - global_rank
+        - world_size
+    """
+    
+    params.local_rank=int(os.environ["LOCAL_RANK"])
+    params.node_id=0
+    params.n_nodes=1
+    params.global_rank=int(os.environ["RANK"])
+    params.world_size=int(os.environ["WORLD_SIZE"])
+    # define whether this is the master process / if we are in distributed mode
+    params.is_main = params.node_id == 0 and params.local_rank == 0
+    params.multi_node = params.n_nodes > 1
+    params.multi_gpu = params.world_size > 1
+    params.is_distributed = True
+
+    # summary
+    PREFIX = "%i - " % params.global_rank
+    # define master address
+    # tbc
+    # set GPU device
+    if params.is_distributed:
+        torch.cuda.set_device(params.local_rank)
+        device = torch.device("cuda", params.local_rank)
+    else:
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    params.device = device
+
+    # initialize multi-GPU
+    if params.is_distributed:
+
+        # http://pytorch.apachecn.org/en/0.3.0/distributed.html#environment-variable-initialization
+        # 'env://' will read these environment variables:
+        # WORLD_SIZE - required; can be set either here, or in a call to init function
+        # RANK - required; can be set either here, or in a call to init function
+
+        # print("Initializing PyTorch distributed ...")
+        # Fix for if gloo sockets are inconsistent
+        p1 = subprocess.Popen(["ip", "r"], stdout=subprocess.PIPE)
+        p2 = subprocess.Popen(["grep", "default"], stdin=p1.stdout, stdout=subprocess.PIPE)
+        p1.stdout.close()
+        gloo_socket_ifname = subprocess.check_output(["awk", "{print $5}"], stdin=p2.stdout).decode("utf-8").strip()
+        p2.stdout.close()
+        os.environ["GLOO_SOCKET_IFNAME"] = gloo_socket_ifname
+
+        torch.distributed.init_process_group(
+            init_method="env://",
+            backend="nccl",
+        )
+
+        global GLOO_GROUP
+
+        GLOO_GROUP = torch.distributed.new_group(
+            list(range(params.world_size)), backend="gloo", timeout=datetime.timedelta(0, 600)
+        )
+    
+    

--- a/src/torchrun_utils.py
+++ b/src/torchrun_utils.py
@@ -16,6 +16,7 @@ import torch
 
 logger = getLogger()
 
+
 def init_distributed_mode_torchrun(params):
     """
     Handle single and multi-GPU for singe-node jobs with torchrun.
@@ -26,12 +27,19 @@ def init_distributed_mode_torchrun(params):
         - global_rank
         - world_size
     """
-    
-    params.local_rank=int(os.environ["LOCAL_RANK"])
-    params.node_id=0
-    params.n_nodes=1
-    params.global_rank=int(os.environ["RANK"])
-    params.world_size=int(os.environ["WORLD_SIZE"])
+    # for NCCL verbose mode
+    os.environ["NCCL_DEBUG"] = "INFO"
+    # os.environ["NCCL_DEBUG_SUBSYS"]="ALL"
+    # os.environ["NCCL_P2P_DISABLE"]="1"
+    # os.environ["CUDA_LAUNCH_BLOCKING"]="1"
+    # os.environ["NCCL_IB_DISABLE"]="1"
+    # os.environ["NCCL_LL_THRESHOLD"]="0" #try this
+    # os.environ["MKL_NUM_THREADS"]="1"
+    params.local_rank = int(os.environ["LOCAL_RANK"])
+    params.node_id = 0
+    params.n_nodes = 1
+    params.global_rank = int(os.environ["RANK"])
+    params.world_size = int(os.environ["WORLD_SIZE"])
     # define whether this is the master process / if we are in distributed mode
     params.is_main = params.node_id == 0 and params.local_rank == 0
     params.multi_node = params.n_nodes > 1
@@ -77,5 +85,3 @@ def init_distributed_mode_torchrun(params):
         GLOO_GROUP = torch.distributed.new_group(
             list(range(params.world_size)), backend="gloo", timeout=datetime.timedelta(0, 600)
         )
-    
-    


### PR DESCRIPTION
This PR:
- Adds torchrun support to run the `finetune_qa.py` in a user-friendly way. In a machine with 8 GPUs, we can run:

`torchrun --standalone --nnodes 1 --nproc_per_node 8  finetune_qa.py --train_data $DATA_DIR/nq_data/train.100-shot.jsonl --eval_data $DATA_DIR/nq_data/test.jsonl --name "my_finetuning_experiment"  --checkpoint_dir $DATA_DIR/experiments/ --total_steps 31 --index_mode faiss --faiss_index_type  pq --faiss_code_size 16 --model_path $DATA_DIR/models/atlas/base --load_index_path $DATA_DIR/indices/atlas/wiki/base --reader_model_type  google/t5-base-lm-adapt`
- It fixes an issue with the `_add_embeddings_by_chunks()` method that was not including all embeddings since it assumed  that the range interval when slicing was `[start,end]` but it is `[start,end)` , e.g. it excludes the last value.

- It adds a missing config for the GpuIndexFlatIP and its corresponding type.